### PR TITLE
Add utilities and notebook for CoT latent dynamics

### DIFF
--- a/notebooks/cot_latent_dynamics.ipynb
+++ b/notebooks/cot_latent_dynamics.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3391c8b7",
+   "metadata": {},
+   "source": [
+    "# CoT Latent Dynamics\n",
+    "This notebook explores how chain-of-thought (CoT) moves in latent space across chunks using simple trajectory metrics and visualizations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfdd57dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import torch\n",
+    "from transformers import AutoTokenizer, AutoModelForCausalLM\n",
+    "from utils import (\n",
+    "    split_solution_into_chunks,\n",
+    "    get_chunk_embeddings,\n",
+    "    compute_trajectory_metrics,\n",
+    "    reduce_embeddings,\n",
+    "    plot_trajectory,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea0cf689",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "model_name = 'distilgpt2'\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name, output_hidden_states=True).to(device)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "prompt = 'Question: what is 2+3? Let's think step by step.'\n",
+    "input_ids = tokenizer(prompt, return_tensors='pt').input_ids.to(device)\n",
+    "with torch.no_grad():\n",
+    "    output_ids = model.generate(input_ids, max_new_tokens=40, do_sample=False)\n",
+    "text = tokenizer.decode(output_ids[0], skip_special_tokens=True)\n",
+    "print(text)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "401cef9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chunks, embeddings = get_chunk_embeddings(model, tokenizer, text, device=device)\n",
+    "print(chunks)\n",
+    "metrics = compute_trajectory_metrics(embeddings)\n",
+    "projection = reduce_embeddings(embeddings)\n",
+    "fig = plot_trajectory(projection, chunks, save_path='generated_data/figures/cot_latent_trajectory.png')\n",
+    "fig\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8a8d238",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary_path = Path('generated_data/figures/cot_latent_summary.txt')\n",
+    "summary_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "with open(summary_path, 'w') as f:\n",
+    "    f.write('Distances between successive chunks:\n",
+    "')\n",
+    "    for i, d in enumerate(metrics['distances']):\n",
+    "        f.write(f'{i}->{i+1}: {float(d):.4f}\n",
+    "')\n",
+    "summary_path\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12df0166",
+   "metadata": {},
+   "source": [
+    "## Comparison with Thought Anchors\n",
+    "Attempt to compare the trajectory metrics with counterfactual importance from the Thought Anchors paper. This section is optional and will skip if the reference code is unavailable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba54acda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import sys\n",
+    "    sys.path.append('refs/thought-anchors')\n",
+    "    from step_attribution import compute_step_importance_matrix\n",
+    "    importance, chunk_texts = compute_step_importance_matrix(chunks)\n",
+    "    print('Counterfactual importance matrix shape:', importance.shape)\n",
+    "except Exception as e:\n",
+    "    print('Thought anchors comparison unavailable:', e)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- handle optional imports for `nnsight` and API clients in `utils`
- add helper functions for chunk embedding trajectories and plotting
- add `cot_latent_dynamics.ipynb` demo notebook exploring CoT movement in latent space

## Testing
- `pytest tests/test_find_steering_anchors.py::test_compute_chunk_vectors_alignment_tiny_model -q` *(fails: ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b1715f1944832eb929f0fcba381784